### PR TITLE
戦闘力グラフのmin/max-heightを指定

### DIFF
--- a/app/assets/stylesheets/canvas.scss
+++ b/app/assets/stylesheets/canvas.scss
@@ -1,0 +1,4 @@
+#lineChartCanvas{
+  // どのデバイスでも画面内に収まるように
+  max-height: 60vh !important;
+}

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -24,3 +24,11 @@ footer {
   width: 100%;
   height: 80px;
 }
+
+.power-result-wrap {
+  min-height: 80vh;
+}
+
+.power-graph {
+  max-height: 90vh;
+}

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -1,37 +1,40 @@
 / TODO デザインは未反映
-.power
-  | あなたの戦闘力は
-  = get_sum_power(@user, 'total')
-  | です
-  span.small.blink
-    | ↑
-    = @user.today_increase_power
-  p.small
-    | 次のキャラまで
-    = @user.up_to_next_character
-    | 戦闘力
-.name
-  | あなたは
-  = @user.character_name
-  | です
-.text
-  p
-    = @user.character_introduction
-script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.1/Chart.min.js"
-h3.text-center
-  | 戦闘力遷移
-#graph_tabs.nav-tabs-custom
-  ul.nav.nav-tabs.nav-tabs-extend
-    li.nav-item.col-3.col-lg-2.p-0.text-center
-      a#week.ajax-link.nav-link[href="javascript:void(0)"]
-        | 1week
-    li.nav-item.col-3.col-lg-2.p-0.text-center
-      a#month.ajax-link.nav-link.tab--active[href="javascript:void(0)"]
-        | 1month
-    li.nav-item.col-3.col-lg-2.p-0.text-center
-      a#quarter.ajax-link.nav-link[href="javascript:void(0)"]
-        | 3months
-    li.nav-item.col-3.col-lg-2.p-0.text-center
-      a#year.ajax-link.nav-link[href="javascript:void(0)"]
-        | 1year
-canvas#lineChartCanvas data-user_id = @user.id
+.power-result-wrap
+  .power
+    | あなたの戦闘力は
+    = get_sum_power(@user, 'total')
+    | です
+    span.small.blink
+      | ↑
+      = @user.today_increase_power
+    p.small
+      | 次のキャラまで
+      = @user.up_to_next_character
+      | 戦闘力
+  .name
+    | あなたは
+    = @user.character_name
+    | です
+  .text
+    p
+      = @user.character_introduction
+  script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.1/Chart.min.js"
+  .power-graph
+    h3.text-center
+      | 戦闘力遷移
+    #graph_tabs.nav-tabs-custom
+      ul.nav.nav-tabs.nav-tabs-extend
+        li.nav-item.col-3.col-lg-2.p-0.text-center
+          a#week.ajax-link.nav-link[href="javascript:void(0)"]
+            | 1week
+        li.nav-item.col-3.col-lg-2.p-0.text-center
+          a#month.ajax-link.nav-link.tab--active[href="javascript:void(0)"]
+            | 1month
+        li.nav-item.col-3.col-lg-2.p-0.text-center
+          a#quarter.ajax-link.nav-link[href="javascript:void(0)"]
+            | 3months
+        li.nav-item.col-3.col-lg-2.p-0.text-center
+          a#year.ajax-link.nav-link[href="javascript:void(0)"]
+            | 1year
+    .lineChartCanvas
+      canvas#lineChartCanvas data-user_id = @user.id


### PR DESCRIPTION
# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
下記問題の対応
> ### 関連issue #50 戦闘力遷移グラフタブ押下でスクロール位置がトップになる時がある問題
# 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- 戦闘力結果画面のmin-heghtを設定
原因は、chartを一旦destroyした際、body内のコンテンツがheight:100%より下回ってしまったため、トップにスクロールしてしまったと考えました。
戦闘力結果画面の戦闘力情報やグラフを含めた要素のmin-heightを設定することで解決しました。
- グラフ領域にmax-heightを設定
デバイスによっては、グラフがheight:100%を超えて表示されてしまい、見にくいため設定。