### PR TITLE
初回ログイン後その日のうちに2回目の戦闘力を測る動作を行わなかったユーザーが次の日以降戦闘力を測定できなくなるバグを修正

### DIFF
--- a/app/models/twitter_API.rb
+++ b/app/models/twitter_API.rb
@@ -48,9 +48,8 @@ class TwitterAPI
 
       # 初回ログイン時にいいねのトータル回数の初期値を入れるため、yesterday_valueにtotal_favを代入している。よって初回ログイン時のいいねのポイントは無効化。
       if activity == nil
-        Activity.create(user_id: user.id, action_id: 1, yesterday_value: total_fav)
-        yesterday_fav = total_fav
-        @fav = @@fav_point * (total_fav - yesterday_fav)
+        Activity.create(user_id: user.id, action_id: 1, yesterday_value: total_fav, latest_value: total_fav)
+        @fav = @@fav_point * 0
         # 初期値を入れた後は、戦闘力を測るたびにlatest_valueに最新のトータルいいね数が更新され続け、yesterday_valueとの差分で1日のいいね数を計測。latest_valueはcronにより毎日0時に更新され、yesterday_valueに格納される
       else
         yesterday_fav = Activity.find_by(user_id: user.id, action_id: 1).yesterday_value


### PR DESCRIPTION
# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
題名の通りです
# 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

# 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->

# 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->

# 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
