### PR TITLE
crontabのログ出力先を変更

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,4 +1,11 @@
-set :output, '/usr/src/app/log/crontab.log'
+# Rails.rootを使用するために必要
+require File.expand_path(File.dirname(__FILE__) + "/environment")
+# cronを実行する環境変数
+rails_env = ENV['RAILS_ENV'] || :development
+# cronを実行する環境変数をセット
+set :environment, rails_env
+# cronのログの吐き出し場所
+set :output, "#{Rails.root}/log/cron.log"
 
 every 1.day, at: '0:00 am' do
   rake 'yesterday_value:update'


### PR DESCRIPTION
# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
crontabのログ出力先を変更
# 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
### 修正前
`/usr/src/app/log/`になっていた。
このディレクトリがないので、cronが実行されていなかった。
### 修正後
`/var/www/scoutter/current/log/crontab.log`になるよう変更。
