### PR TITLE
自分の順位を見るURL決定を押下時に決めるよう変更

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -21,6 +21,19 @@ class UsersController < ApplicationController
     @ranks = @users.page(params[:page]).per(25)
   end
 
+  def my_rank
+    case @period = params[:period] || 'total'
+    when 'total'
+      @users = User.power_rank.total_period
+    when 'week'
+      @users = User.power_rank.week_period
+    when 'day'
+      @users = User.power_rank.day_period
+    end
+    @ranks = @users.page(params[:page]).per(25)
+    redirect_to ranking_path(view_context.my_rank_query)
+  end
+
   # FIXME：コントローラ内でURLの設定はしたくないので、concerns等の他の場所に退避する
   #        その際に、link_toから戦闘力、キャラ名を受け取るのではなく、直接取得出来るようにすることが望ましい
   def set_share_url

--- a/app/helpers/rank_helper.rb
+++ b/app/helpers/rank_helper.rb
@@ -10,6 +10,6 @@ module RankHelper
       page_number += 1
       order = nil
     end
-    { page: page_number, anchor: order }
+    { page: page_number, period: @period, anchor: order }
   end
 end

--- a/app/views/users/rank.html.slim
+++ b/app/views/users/rank.html.slim
@@ -13,6 +13,6 @@
   = paginate @ranks, theme: 'rank',
     pagination_class: 'pagination-sm'
   .text-center
-    = link_to ranking_path(my_rank_query), class: 'btn btn-rank fuwafuwa m-0 bit-10' do
+    = link_to ranking_self_path(period: @period), class: 'btn btn-rank fuwafuwa m-0 bit-10' do
       | 自分の順位を見る
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,11 +3,12 @@ Rails.application.routes.draw do
     get '/login_as/:user_id', to: 'development/sessions#login_as'
   end
   get '/ranking', to: 'users#rank'
+  get '/ranking/self', to: 'users#my_rank'
   post 'oauth/callback' => 'oauths#callback'
   get 'oauth/callback' => 'oauths#callback'
   get 'oauth/:provider' => 'oauths#oauth', as: :auth_at_provider
   resources :users, only: %i[show]
   get '/users/:id/share_twitter' => 'users#set_share_url', as: :share_twitter
-  root to: 'home#index'
   get '/term' => 'home#term'
+  root to: 'home#index'
 end


### PR DESCRIPTION
# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
自分の戦闘力を見るボタンのURL先が、表示時に決まっていたので、その間順位が変わると違う場所にとんでいた。押下時にURLを決定しリダイレクトするよう変更