### PR TITLE
ランキングで戦闘力が同率のときの並び替えを追加

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,8 +18,7 @@ class User < ApplicationRecord
   scope :power_rank, -> do
     joins(:sum_power)
       .includes(:character, :sum_power)
-      .with_attached_icon
-      .order('sum_powers.power desc')
+      .order('sum_powers.power desc, users.id desc')
   end
   scope :total_period, -> { merge(SumPower.total) }
   scope :week_period, -> { merge(SumPower.week) }


### PR DESCRIPTION
# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
いままで同率戦闘力の人の並び順がランダムだったため、同率の場合自分の順位へ飛べなかった。
戦闘力が同率の場合ユーザーIDの降順で並び替えるよう変更。（新規ユーザーの方が順位が上に来るように）