### PR TITLE
twitter_idの命名の重複を修正

### DIFF
--- a/app/models/concerns/twitter_API.rb
+++ b/app/models/concerns/twitter_API.rb
@@ -25,7 +25,7 @@ module TwitterAPI
     twitter_client.user(self.uid).name
   end
 
-  def twitter_id
+  def twitter_screen_name
     twitter_client.user(self.uid).screen_name
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -60,7 +60,7 @@ class User < ApplicationRecord
 
   def refresh_by_twitter
     self.name = self.user_name
-    self.twitter_id = self.twitter_id
+    self.twitter_id = self.twitter_screen_name
     self.image = self.profile_image
     save if changed?
   end


### PR DESCRIPTION
# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
Userの`twitter_id`プロパティ名と、TwitterAPIの`twitter_id`(Twitterのユーザーの@◯◯を取得)のメソッド名がかぶっていたので、意図せずAPIを呼んでいた。
# 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
APIの方を`twitter_screen_name`に変更